### PR TITLE
MINOR: Issue #14 Hardcoded Links

### DIFF
--- a/code/Post.php
+++ b/code/Post.php
@@ -177,7 +177,7 @@ class Post extends DataObject {
 		if($this->canEdit()) {
 			$url = Controller::join_links($this->Link('editpost'), $this->ID);
 
-			return '<a href="' . $url . '" class="editPostLink">' . _t('Post.EDIT','Edit') . '</a>';
+			return $url;
 		}
 		
 		return false;
@@ -194,9 +194,8 @@ class Post extends DataObject {
 	function DeleteLink() {
 		if($this->canDelete()) {
 			$url = $this->Link('deletepost') . '/' . $this->ID;
-			$firstPost = ($this->isFirstPost()) ? ' firstPost' : '';
-
-			return '<a class="deleteLink' . $firstPost . '" href="' . $url . '">' . _t('Post.DELETE','Delete') . '</a>';
+                        
+			return $url;
 		}
 		
 		return false;
@@ -210,8 +209,8 @@ class Post extends DataObject {
 	 */
 	function ReplyLink() {
 		$url = $this->Link('reply');
-
-		return '<a href="' . $url . '" class="replyLink">' . _t('Post.REPLYLINK','Post Reply') . '</a>';
+                
+		return $url;
 	}
 		
 	/**
@@ -222,7 +221,7 @@ class Post extends DataObject {
 	function ShowLink() {
 		$url = $this->Link('show');
 		
-		return '<a href="' . $url . '" class="showLink">' . _t('Post.SHOWLINK','Show Thread') . "</a>";
+		return $url;
 	}
 	
 	/**
@@ -236,11 +235,12 @@ class Post extends DataObject {
 			$member = Member::currentUser();
 		 	if($member->ID != $this->AuthorID) {
 				$link = $this->Forum()->Link('markasspam') . '/' . $this->ID;
-				$firstPost = ($this->isFirstPost()) ? ' firstPost' : '';
 				
-				return '<a href="' . $link .'" class="markAsSpamLink' . $firstPost . '" rel="' . $this->ID . '">'. _t('Post.MARKASSPAM', 'Mark as Spam') . '</a>';
+				return $link;
 			}
 		}
+		
+		return false;
 	}
 
 	/**

--- a/templates/Includes/ForumLogin.ss
+++ b/templates/Includes/ForumLogin.ss
@@ -1,7 +1,7 @@
 <div id="RegisterLogin">
 	<% if CurrentMember %>
 		<p>
-			<% _t('LOGGEDINAS','You\'re logged in as') %> <% if CurrentMember.Nickname %>$CurrentMember.Nickname<% else %><% _t('ANONYMOUS','Anonymous') %><% end_if %> | 
+			<%t ForumLogin.ss.LOGGEDINAS %> <% if CurrentMember.Nickname %>$CurrentMember.Nickname<% else %><% _t('ANONYMOUS','Anonymous') %><% end_if %> | 
 			<a href="$ForumHolder.Link(logout)" title="<% _t('LOGOUTEXPLICATION','Click here to log out') %>"><% _t('LOGOUT','Log Out') %></a> | <a href="ForumMemberProfile/edit" title="<% _t('PROFILEEXPLICATION','Click here to edit your profile') %>"><% _t('PROFILE','Profile') %></a></p>
 	<% else %>
 		<p>

--- a/templates/Includes/SinglePost.ss
+++ b/templates/Includes/SinglePost.ss
@@ -21,7 +21,9 @@
 
 		<div class="quick-reply">
 			<% if Thread.canPost %>
-				<p>$Top.ReplyLink</p>
+				<p>
+				    <a href="$Top.ReplyLink" class="replyLink"><%t Post.REPLYLINK %></a>
+				</p>
 			<% end_if %>
 		</div>
 		<h4><a href="$Link">$Title <img src="forum/images/right.png" alt="Link to this post" title="Link to this post" /></a></h4>
@@ -33,15 +35,15 @@
 		<% if EditLink || DeleteLink %>
 			<div class="post-modifiers">
 				<% if EditLink %>
-					$EditLink
+					<a href="$EditLink" class="editPostLink"><%t Post.EDIT %></a>
 				<% end_if %>
 				
 				<% if DeleteLink %>
-					$DeleteLink
+					<a href="$DeleteLink" class="deleteLink"><%t Post.DELETE %></a>
 				<% end_if %>
 				
 				<% if MarkAsSpamLink %>
-					$MarkAsSpamLink
+					<a href="$MarkAsSpamLink" class="markAsSpamLink" rel="$ID"><%t Post.MARKASSPAM %></a>
 				<% end_if %>
 			</div>
 		<% end_if %>


### PR DESCRIPTION
There are still occurences of href in the code (mostly for breadcrumbs, forms and literal fields) that are out of the template scope.

The unused css-class "isfirstpost" was skipped. A t-function in ForumLogin.ss had to be updated to prevent an error.
