### PR TITLE
FIX: Fixed wrong SQL syntax when searching with ForumDatabaseSearch

### DIFF
--- a/code/search/ForumDatabaseSearch.php
+++ b/code/search/ForumDatabaseSearch.php
@@ -35,7 +35,7 @@ class ForumDatabaseSearch implements ForumSearchProvider {
 		$SQL_authorClause = '';
 		$SQL_potentialAuthorIDs = array();
 		
-		if($potentialAuthors) {
+		if($potentialAuthors->exists()) {
 			foreach($potentialAuthors as $potentialAuthor) {
 				$SQL_potentialAuthorIDs[] = $potentialAuthor->ID;
 			}


### PR DESCRIPTION
The expression 'if($potentialAuthors)' will always be true.
This will cause wrong SQL syntax when there is no matching Member for the given search term.
