### PR TITLE
Update Forum.php

### DIFF
--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -492,7 +492,7 @@ class Forum_Controller extends Page_Controller {
 		Requirements::javascript("forum/javascript/forum.js");
 		Requirements::javascript("forum/javascript/jquery.MultiFile.js");
 
-		Requirements::themedCSS('forum','forum','all');
+		Requirements::themedCSS('Forum','forum','all');
 
 		RSSFeed::linkToFeed($this->Parent()->Link("rss/forum/$this->ID"), sprintf(_t('Forum.RSSFORUM',"Posts to the '%s' forum"),$this->Title)); 
 	 	RSSFeed::linkToFeed($this->Parent()->Link("rss"), _t('Forum.RSSFORUMS','Posts to all forums'));


### PR DESCRIPTION
The routine Requirements::themedCSS needs a valid filename without extension. The filename in the template directory is "Forum.css", not "forum.css". So the statement has to be changed and the Forum.css is registered and working.
