### PR TITLE
Update ForumMember_TopicNotification.ss

### DIFF
--- a/templates/email/ForumMember_TopicNotification.ss
+++ b/templates/email/ForumMember_TopicNotification.ss
@@ -1,6 +1,6 @@
 <p><% sprintf(_t('ForumMember_TopicNotification_ss.HI',"Hi %s,"),$Nickname) %></p>
 
-<p><% _t('ForumMember_TopicNotification_ss.NEWPOSTMESSAGE',"A new post has been added to a topic you've subscribed to") %> - '$Title' <% if Author %><% _t('BY', "by") %> $Author.Nickname.<% end_if %></p>
+<p><% _t('ForumMember_TopicNotification_ss.NEWPOSTMESSAGE',"A new post has been added to a topic you've subscribed to") %> - '$Title' <% if Author %><% _t('BY', "by") %> $Author.Nickname .<% end_if %></p>
 
 <ul>
 	<li><a href="$Link"><% _t('ForumMember_TopicNotification_ss.REPLYLINK', "View the topic") %></a></li>


### PR DESCRIPTION
The dot immediately following the $Author.Nickname leads to an exception, when a notification is generated, so follow $Author.Nickname by a space!
