### PR TITLE
Delete avatar on deletion of a Member who has one.

### DIFF
--- a/code/extensions/ForumRole.php
+++ b/code/extensions/ForumRole.php
@@ -83,6 +83,15 @@ class ForumRole extends DataExtension {
 		'SuspendedUntil' => "Suspend this member from writing on forums until the specified date"
 	);
 
+	public function onBeforeDelete() {
+		parent::onBeforeDelete();
+
+		$avatar = $this->owner->Avatar();
+		if($avatar && $avatar->exists()) {
+			$avatar->delete();
+		}
+	}
+
 	function ForumRank() {
 		$moderatedForums = $this->owner->ModeratedForums();
 		if($moderatedForums && $moderatedForums->Count() > 0) return _t('MODERATOR','Forum Moderator');


### PR DESCRIPTION
Currently if we remove spam users some of their files are left hanging
around. This removes the linked avatar if the user is deleted.
