### PR TITLE
Fix performance dramatically for large Post tables

### DIFF
--- a/code/model/ForumThread.php
+++ b/code/model/ForumThread.php
@@ -32,6 +32,11 @@ class ForumThread extends DataObject {
 		'IsGlobalSticky' => false
 	);
 
+	private static $indexes = array(
+		'IsSticky' => true,
+		'IsGlobalSticky' => true
+	);
+
 	/**
 	 * @var null|boolean Per-request cache, whether we should display signatures on a post.
 	 */


### PR DESCRIPTION
Pre-filter the sub-select of Post in these queries, which massively
improves performance on large Post tables.

Add indexes to ForumThread as well which helps across the board.
