### PR TITLE
Update email call for replies to use translatable subject

### DIFF
--- a/code/controllers/ForumMemberProfile.php
+++ b/code/controllers/ForumMemberProfile.php
@@ -52,7 +52,7 @@ class ForumMemberProfile extends Page_Controller {
 	 * Initialise the controller
 	 */
 	function init() {
-		Requirements::themedCSS('forum','forum','all');
+		Requirements::themedCSS('Forum','forum','all');
 		$member = $this->Member() ? $this->Member() : null;
 		$nicknameText = ($member) ? ($member->Nickname . '\'s ') : '';
 		

--- a/code/model/ForumThread.php
+++ b/code/model/ForumThread.php
@@ -302,7 +302,7 @@ class ForumThread_Subscription extends DataObject {
 					$email = new Email();
 					$email->setFrom(Email::getAdminEmail());
 					$email->setTo($member->Email);
-					$email->setSubject('New reply for ' . $post->Title);
+					$email->setSubject(_t('Post.NEWREPLY', 'New reply for') . " " . $post->Title);
 					$email->setTemplate('ForumMember_TopicNotification');
 					$email->populateTemplate($member);
 					$email->populateTemplate($post);

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -180,6 +180,8 @@ de:
     RESPONSE: "Re: %s"
     SHOWLINK: "Zeige Thema"
     SINGULARNAME: "Beitrag"
+    NEWREPLY: "Neue Antwort zu"
+
   SinglePost_ss:
     ATTACHED: "Anhänge"
     GOTOPROFILE: "Gehe zum Profil dieses Benutzers"


### PR DESCRIPTION
ForumThread.php and lang/de.yml should be changed so that international subjects for replies will be generated

Regards
Walter