### PR TITLE
FIX Title validation in first forum post

### DIFF
--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -731,9 +731,13 @@ class Forum_Controller extends Page_Controller {
 	 *
 	 * @return Form Returns the post message form
 	 */
-	function PostMessageForm($addMode = false, $post = false) {
-		$thread = false;
+	function PostMessageForm($addMode = true, $post = false) {
+		if (!$addMode || $addMode == 'false') {
+    			$addMode = false;
+		}
 
+		$thread = false;
+		
 		if($post) {
 			$thread = $post->Thread();
 		} else if(isset($this->urlParams['ID']) && is_numeric($this->urlParams['ID'])) {
@@ -819,7 +823,7 @@ class Forum_Controller extends Page_Controller {
 			new FormAction("doPostMessageForm", _t('Forum.REPLYFORMPOST', 'Post'))
 		);
 
-		$required = $addMode === true ? new RequiredFields("Title", "Content") : new RequiredFields("Content");
+		$required = $addMode == 'true' ? new RequiredFields("Title", "Content") : new RequiredFields("Content");
 
 		$form = new Form($this, 'PostMessageForm', $fields, $actions, $required);
 

--- a/templates/Layout/Forum_reply.ss
+++ b/templates/Layout/Forum_reply.ss
@@ -1,5 +1,5 @@
 <% include ForumHeader %>
-	$PostMessageForm
+	$PostMessageForm(false)
 	
 	<div id="PreviousPosts">
 		<ul id="Posts">


### PR DESCRIPTION
This is a fix for #124, added quotation marks to validation as the variable was a string rather than a boolean.