### PR TITLE
Wrapping getCMSFields fields with beforeUpdateCMSFields - master version

### DIFF
--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -209,71 +209,77 @@ class Forum extends Page {
 	 * @return FieldList The fields to be displayed in the CMS.
 	 */
 	function getCMSFields() {
-		Requirements::javascript("forum/javascript/ForumAccess.js");
-		Requirements::css("forum/css/Forum_CMS.css");
-
-	  	$fields = parent::getCMSFields();
+		$self = $this;
+		
+		$this->beforeUpdateCMSFields(function($fields) use ($self) {
+			Requirements::javascript("forum/javascript/ForumAccess.js");
+			Requirements::css("forum/css/Forum_CMS.css");
+			
+			$fields->addFieldToTab("Root.Access", new HeaderField(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
+		
+			$fields->addFieldToTab("Root.Access", new HeaderField(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
+			$fields->addFieldToTab("Root.Access", $optionSetField = new OptionsetField("CanPostType", "", array(
+				"Inherit" => "Inherit",
+				"Anyone" => _t('Forum.READANYONE', 'Anyone'),
+				"LoggedInUsers" => _t('Forum.READLOGGEDIN', 'Logged-in users'),
+				"OnlyTheseUsers" => _t('Forum.READLIST', 'Only these people (choose from list)'),
+				"NoOne" => _t('Forum.READNOONE', 'Nobody. Make Forum Read Only')
+			)));
 	
-		$fields->addFieldToTab("Root.Access", new HeaderField(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
-		$fields->addFieldToTab("Root.Access", $optionSetField = new OptionsetField("CanPostType", "", array(
-			"Inherit" => "Inherit",
-		  	"Anyone" => _t('Forum.READANYONE', 'Anyone'),
-		  	"LoggedInUsers" => _t('Forum.READLOGGEDIN', 'Logged-in users'),
-		  	"OnlyTheseUsers" => _t('Forum.READLIST', 'Only these people (choose from list)'),
-			"NoOne" => _t('Forum.READNOONE', 'Nobody. Make Forum Read Only')
-		)));
-
-		$optionSetField->addExtraClass('ForumCanPostTypeSelector');
-
-		$fields->addFieldsToTab("Root.Access", array( 
-			new TreeMultiselectField("PosterGroups", _t('Forum.GROUPS',"Groups")),
-			new OptionsetField("CanAttachFiles", _t('Forum.ACCESSATTACH','Can users attach files?'), array(
-				"1" => _t('Forum.YES','Yes'),
-				"0" => _t('Forum.NO','No')
-			))
-		));
-
-
-		//Dropdown of forum category selection.
-		$categories = ForumCategory::get()->map();
-
-		$fields->addFieldsToTab(
-			"Root.Main",
-			DropdownField::create('CategoryID', _t('Forum.FORUMCATEGORY', 'Forum Category'), $categories),
-			'Content'
-		);
-
-		//GridField Config - only need to attach or detach Moderators with existing Member accounts.
-		$moderatorsConfig = GridFieldConfig::create()
-			->addComponent(new GridFieldButtonRow('before'))
-			->addComponent(new GridFieldAddExistingAutocompleter('buttons-before-right'))
-			->addComponent(new GridFieldToolbarHeader())
-			->addComponent($sort = new GridFieldSortableHeader())
-			->addComponent($columns = new GridFieldDataColumns())
-			->addComponent(new GridFieldDeleteAction(true))
-			->addComponent(new GridFieldPageCount('toolbar-header-right'))
-			->addComponent($pagination = new GridFieldPaginator());
-
-		// Use GridField for Moderator management
-		$moderators = GridField::create(
-			'Moderators',
-			_t('MODERATORS', 'Moderators for this forum'),
-			$this->Moderators(),
-			$moderatorsConfig
+			$optionSetField->addExtraClass('ForumCanPostTypeSelector');
+	
+			$fields->addFieldsToTab("Root.Access", array( 
+				new TreeMultiselectField("PosterGroups", _t('Forum.GROUPS',"Groups")),
+				new OptionsetField("CanAttachFiles", _t('Forum.ACCESSATTACH','Can users attach files?'), array(
+					"1" => _t('Forum.YES','Yes'),
+					"0" => _t('Forum.NO','No')
+				))
+			));
+	
+	
+			//Dropdown of forum category selection.
+			$categories = ForumCategory::get()->map();
+	
+			$fields->addFieldsToTab(
+				"Root.Main",
+				DropdownField::create('CategoryID', _t('Forum.FORUMCATEGORY', 'Forum Category'), $categories),
+				'Content'
 			);
-
-		$columns->setDisplayFields(array(
-			'Nickname' => 'Nickname',
-			'FirstName' => 'First name',
-			'Surname' => 'Surname',
-			'Email'=> 'Email',
-			'LastVisited.Long' => 'Last Visit'
-		));
-
-		$sort->setThrowExceptionOnBadDataType(false);
-		$pagination->setThrowExceptionOnBadDataType(false);
-
-		$fields->addFieldToTab('Root.Moderators', $moderators);
+	
+			//GridField Config - only need to attach or detach Moderators with existing Member accounts.
+			$moderatorsConfig = GridFieldConfig::create()
+				->addComponent(new GridFieldButtonRow('before'))
+				->addComponent(new GridFieldAddExistingAutocompleter('buttons-before-right'))
+				->addComponent(new GridFieldToolbarHeader())
+				->addComponent($sort = new GridFieldSortableHeader())
+				->addComponent($columns = new GridFieldDataColumns())
+				->addComponent(new GridFieldDeleteAction(true))
+				->addComponent(new GridFieldPageCount('toolbar-header-right'))
+				->addComponent($pagination = new GridFieldPaginator());
+	
+			// Use GridField for Moderator management
+			$moderators = GridField::create(
+				'Moderators',
+				_t('MODERATORS', 'Moderators for this forum'),
+				$self->Moderators(),
+				$moderatorsConfig
+				);
+	
+			$columns->setDisplayFields(array(
+				'Nickname' => 'Nickname',
+				'FirstName' => 'First name',
+				'Surname' => 'Surname',
+				'Email'=> 'Email',
+				'LastVisited.Long' => 'Last Visit'
+			));
+	
+			$sort->setThrowExceptionOnBadDataType(false);
+			$pagination->setThrowExceptionOnBadDataType(false);
+	
+			$fields->addFieldToTab('Root.Moderators', $moderators);
+		});
+		
+		$fields = parent::getCMSFields();
 
 		return $fields;
 	}

--- a/code/pagetypes/ForumHolder.php
+++ b/code/pagetypes/ForumHolder.php
@@ -83,66 +83,73 @@ class ForumHolder extends Page {
 	private static $currently_online_enabled = true;
 
 	function getCMSFields() {
-		$fields = parent::getCMSFields();
-		$fields->addFieldsToTab("Root.Messages", array(
-			TextField::create("HolderSubtitle","Forum Holder Subtitle"),
-			HTMLEditorField::create("HolderAbstract","Forum Holder Abstract"),
-			TextField::create("ProfileSubtitle","Member Profile Subtitle"),
-			HTMLEditorField::create("ProfileAbstract","Member Profile Abstract"),
-			TextField::create("ForumSubtitle","Create topic Subtitle"),
-			HTMLEditorField::create("ForumAbstract","Create topic Abstract"),
-			HTMLEditorField::create("ProfileModify","Create message after modifing forum member"),
-			HTMLEditorField::create("ProfileAdd","Create message after adding forum member")
-		));
-		$fields->addFieldsToTab("Root.Settings", array(
-			CheckboxField::create("DisplaySignatures", "Display Member Signatures?"),
-			CheckboxField::create("ShowInCategories", "Show Forums In Categories?"),
-			CheckboxField::create("AllowGravatars", "Allow <a href='http://www.gravatar.com/' target='_blank'>Gravatars</a>?"),
-			DropdownField::create("GravatarType", "Gravatar Type", array(
- 		  		"standard" => _t('Forum.STANDARD','Standard'),
- 		  		"identicon" => _t('Forum.IDENTICON','Identicon'),
-		  		"wavatar" => _t('Forum.WAVATAR', 'Wavatar'),
-				"monsterid" => _t('Forum.MONSTERID', 'Monsterid'),
-				"retro" => _t('Forum.RETRO', 'Retro'),
- 				"mm" => _t('Forum.MM', 'Mystery Man'),
- 			))->setEmptyString('Use Forum Default')
-		));
-
-		// add a grid field to the category tab with all the categories
-		$categoryConfig = GridFieldConfig::create()
-			->addComponents(
-				new GridFieldSortableHeader(),
-				new GridFieldButtonRow(),
-				new GridFieldDataColumns(),
-				new GridFieldEditButton(),
-				new GridFieldViewButton(),
-				new GridFieldDeleteAction(),
-				new GridFieldAddNewButton('buttons-before-left'),
-				new GridFieldPaginator(),
-				new GridFieldDetailForm()
-			);
-
-		$categories = GridField::create(
-			'Category',
-			_t('Forum.FORUMCATEGORY', 'Forum Category'),
-			$this->Categories(),
-			$categoryConfig
-		);
-
-		$fields->addFieldsToTab("Root.Categories", $categories);
-
-
-		$fields->addFieldsToTab("Root.LanguageFilter", array(
-			TextField::create("ForbiddenWords", "Forbidden words (comma separated)"),
-			LiteralField::create("FWLabel","These words will be replaced by an asterisk")
-		));
+		$self = $this;
 		
-		$fields->addFieldToTab("Root.Access", HeaderField::create(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
-		$fields->addFieldToTab("Root.Access", OptionsetField::create("CanPostType", "", array(
-		  	"Anyone" => _t('Forum.READANYONE', 'Anyone'),
-		  	"LoggedInUsers" => _t('Forum.READLOGGEDIN', 'Logged-in users'),
-			"NoOne" => _t('Forum.READNOONE', 'Nobody. Make Forum Read Only')
-		)));
+		$this->beforeUpdateCMSFields(function($fields) use ($self) {
+			
+			$fields->addFieldsToTab("Root.Messages", array(
+				TextField::create("HolderSubtitle","Forum Holder Subtitle"),
+				HTMLEditorField::create("HolderAbstract","Forum Holder Abstract"),
+				TextField::create("ProfileSubtitle","Member Profile Subtitle"),
+				HTMLEditorField::create("ProfileAbstract","Member Profile Abstract"),
+				TextField::create("ForumSubtitle","Create topic Subtitle"),
+				HTMLEditorField::create("ForumAbstract","Create topic Abstract"),
+				HTMLEditorField::create("ProfileModify","Create message after modifing forum member"),
+				HTMLEditorField::create("ProfileAdd","Create message after adding forum member")
+			));
+			$fields->addFieldsToTab("Root.Settings", array(
+				CheckboxField::create("DisplaySignatures", "Display Member Signatures?"),
+				CheckboxField::create("ShowInCategories", "Show Forums In Categories?"),
+				CheckboxField::create("AllowGravatars", "Allow <a href='http://www.gravatar.com/' target='_blank'>Gravatars</a>?"),
+				DropdownField::create("GravatarType", "Gravatar Type", array(
+					"standard" => _t('Forum.STANDARD','Standard'),
+					"identicon" => _t('Forum.IDENTICON','Identicon'),
+					"wavatar" => _t('Forum.WAVATAR', 'Wavatar'),
+					"monsterid" => _t('Forum.MONSTERID', 'Monsterid'),
+					"retro" => _t('Forum.RETRO', 'Retro'),
+					"mm" => _t('Forum.MM', 'Mystery Man'),
+				))->setEmptyString('Use Forum Default')
+			));
+	
+			// add a grid field to the category tab with all the categories
+			$categoryConfig = GridFieldConfig::create()
+				->addComponents(
+					new GridFieldSortableHeader(),
+					new GridFieldButtonRow(),
+					new GridFieldDataColumns(),
+					new GridFieldEditButton(),
+					new GridFieldViewButton(),
+					new GridFieldDeleteAction(),
+					new GridFieldAddNewButton('buttons-before-left'),
+					new GridFieldPaginator(),
+					new GridFieldDetailForm()
+				);
+	
+			$categories = GridField::create(
+				'Category',
+				_t('Forum.FORUMCATEGORY', 'Forum Category'),
+				$self->Categories(),
+				$categoryConfig
+			);
+	
+			$fields->addFieldsToTab("Root.Categories", $categories);
+	
+	
+			$fields->addFieldsToTab("Root.LanguageFilter", array(
+				TextField::create("ForbiddenWords", "Forbidden words (comma separated)"),
+				LiteralField::create("FWLabel","These words will be replaced by an asterisk")
+			));
+			
+			$fields->addFieldToTab("Root.Access", HeaderField::create(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
+			$fields->addFieldToTab("Root.Access", OptionsetField::create("CanPostType", "", array(
+				"Anyone" => _t('Forum.READANYONE', 'Anyone'),
+				"LoggedInUsers" => _t('Forum.READLOGGEDIN', 'Logged-in users'),
+				"NoOne" => _t('Forum.READNOONE', 'Nobody. Make Forum Read Only')
+			)));
+			
+		});
+		
+		$fields = parent::getCMSFields();
 
 		return $fields;
 	}


### PR DESCRIPTION
Wrapping `getCMSFields` fields with `beforeUpdateCMSFields` to allow extensions to run after fields have been added. This allows `Forum` and `ForumHolder` fields to be modified or removed in extensions.