### PR TITLE
Explicitly check for admin not canEdit in the canModerate method

### DIFF
--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -5,7 +5,7 @@
  * the site. You can customize permissions on a per forum basis in the CMS.
  *
  * @todo Implement PermissionProvider for editing, creating forums.
- * 
+ *
  * @package forum
  */
 
@@ -31,7 +31,7 @@ class Forum extends Page {
 		"Moderator" => "Member",
 		"Category" => "ForumCategory"
 	);
-	
+
 	private static $many_many = array(
 		'Moderators' => 'Member',
 		'PosterGroups' => 'Group'
@@ -47,7 +47,7 @@ class Forum extends Page {
 	 * @var int
 	 */
 	static $posts_per_page = 8;
-	
+
 	/**
 	 * When migrating from older versions of the forum it used post ID as the url token
 	 * as of forum 1.0 we now use ThreadID. If you want to enable 301 redirects from post to thread ID
@@ -64,7 +64,7 @@ class Forum extends Page {
 		if(!$member) $member = Member::currentUser();
 		return (parent::canView($member) || $this->canModerate($member));
 	}
-	
+
 	/**
 	 * Check if the user can post to the forum and edit his own posts.
 	 */
@@ -79,15 +79,15 @@ class Forum extends Page {
 
 			return false;
 		}
-		
+
 		if($this->CanPostType == "NoOne") return false;
 
 		if($this->CanPostType == "Anyone" || $this->canEdit($member)) return true;
-		
+
 		if($member = Member::currentUser()) {
 			if($member->IsSuspended()) return false;
 			if($member->IsBanned()) return false;
-			
+
 			if($this->CanPostType == "LoggedInUsers") return true;
 
 			if($groups = $this->PosterGroups()) {
@@ -96,7 +96,7 @@ class Forum extends Page {
 				}
 			}
 		}
-		
+
 		return false;
 	}
 
@@ -107,16 +107,16 @@ class Forum extends Page {
 		if(!$member) $member = Member::currentUser();
 
 		if(!$member) return false;
-		
+
 		// Admins
-		if ($this->canEdit($member)) return true; 
+		if (Permission::checkMember($member, 'ADMIN')) return true;
 
 		// Moderators
 		if ($member->isModeratingForum($this)) return true;
 
 		return false;
 	}
-	
+
 	/**
 	 * Can we attach files to topics/posts inside this forum?
 	 *
@@ -134,7 +134,7 @@ class Forum extends Page {
 			if(in_array('ForumPosters', array_keys($fields)) && !in_array('CanPostType', array_keys($fields))) {
 				DB::getConn()->renameField('Forum', 'ForumPosters', 'CanPostType');
 				DB::alteration_message('Migrated forum permissions from "ForumPosters" to "CanPostType"', "created");
-			}	
+			}
 		}
 
 		parent::requireTable();
@@ -157,8 +157,8 @@ class Forum extends Page {
 			$group->write();
 
 			Permission::grant( $group->ID, $code );
-			DB::alteration_message(_t('Forum.GROUPCREATED','Forum Members group created'),'created'); 
-		} 
+			DB::alteration_message(_t('Forum.GROUPCREATED','Forum Members group created'),'created');
+		}
 		else if(!Permission::get()->filter(array('GroupID' => $forumGroup->ID, 'Code' => $code))->exists()) {
 			Permission::grant($forumGroup->ID, $code);
 		}
@@ -213,7 +213,7 @@ class Forum extends Page {
 		Requirements::css("forum/css/Forum_CMS.css");
 
 	  	$fields = parent::getCMSFields();
-	
+
 		$fields->addFieldToTab("Root.Access", new HeaderField(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
 		$fields->addFieldToTab("Root.Access", $optionSetField = new OptionsetField("CanPostType", "", array(
 			"Inherit" => "Inherit",
@@ -225,7 +225,7 @@ class Forum extends Page {
 
 		$optionSetField->addExtraClass('ForumCanPostTypeSelector');
 
-		$fields->addFieldsToTab("Root.Access", array( 
+		$fields->addFieldsToTab("Root.Access", array(
 			new TreeMultiselectField("PosterGroups", _t('Forum.GROUPS',"Groups")),
 			new OptionsetField("CanAttachFiles", _t('Forum.ACCESSATTACH','Can users attach files?'), array(
 				"1" => _t('Forum.YES','Yes'),
@@ -310,10 +310,10 @@ class Forum extends Page {
 
 				if($nonPageParts) {
 					$parts[] = '<a href="' . $page->Link() . '">' . Convert::raw2xml($page->Title) . '</a>';
-				} 
+				}
 				else {
-					$parts[] = (($page->ID == $this->ID) || $unlinked) 
-							? Convert::raw2xml($page->Title) 
+					$parts[] = (($page->ID == $this->ID) || $unlinked)
+							? Convert::raw2xml($page->Title)
 							: '<a href="' . $page->Link() . '">' . Convert::raw2xml($page->Title) . '</a>';
 				}
 			}
@@ -323,9 +323,9 @@ class Forum extends Page {
 
 		return implode(" &raquo; ", array_reverse(array_merge($nonPageParts,$parts)));
 	}
-	
+
 	/**
-	 * Helper Method from the template includes. Uses $ForumHolder so in order for it work 
+	 * Helper Method from the template includes. Uses $ForumHolder so in order for it work
 	 * it needs to be included on this page
 	 *
 	 * @return ForumHolder
@@ -338,7 +338,7 @@ class Forum extends Page {
 	/**
 	 * Get the latest posting of the forum. For performance the forum ID is stored on the
 	 * {@link Post} object as well as the {@link Forum} object
-	 * 
+	 *
 	 * @return Post
 	 */
 	function getLatestPost() {
@@ -417,7 +417,7 @@ class Forum extends Page {
 	}
 
 
-	
+
 	/*
 	 * Returns the Sticky Threads
 	 * @param boolean $include_global Include Global Sticky Threads in the results (default: true)
@@ -477,19 +477,19 @@ class Forum_Controller extends Page_Controller {
 		'ban',
 		'ghost'
 	);
-	
-	
+
+
 	function init() {
 		parent::init();
 		if($this->redirectedTo()) return;
 
-		Requirements::javascript(THIRDPARTY_DIR . "/jquery/jquery.js"); 
+		Requirements::javascript(THIRDPARTY_DIR . "/jquery/jquery.js");
 		Requirements::javascript("forum/javascript/Forum.js");
 		Requirements::javascript("forum/javascript/jquery.MultiFile.js");
 
 		Requirements::themedCSS('Forum','forum','all');
 
-		RSSFeed::linkToFeed($this->Parent()->Link("rss/forum/$this->ID"), sprintf(_t('Forum.RSSFORUM',"Posts to the '%s' forum"),$this->Title)); 
+		RSSFeed::linkToFeed($this->Parent()->Link("rss/forum/$this->ID"), sprintf(_t('Forum.RSSFORUM',"Posts to the '%s' forum"),$this->Title));
 	 	RSSFeed::linkToFeed($this->Parent()->Link("rss"), _t('Forum.RSSFORUMS','Posts to all forums'));
 
  	  	if(!$this->canView()) {
@@ -539,7 +539,7 @@ class Forum_Controller extends Page_Controller {
 
 	/**
 	 * Subscribe a user to a thread given by an ID.
-	 * 
+	 *
 	 * Designed to be called via AJAX so return true / false
 	 *
 	 * @return bool
@@ -554,15 +554,15 @@ class Forum_Controller extends Page_Controller {
 			$obj = new ForumThread_Subscription();
 			$obj->ThreadID = (int) $this->urlParams['ID'];
 			$obj->MemberID = Member::currentUserID();
-			$obj->LastSent = date("Y-m-d H:i:s"); 
+			$obj->LastSent = date("Y-m-d H:i:s");
 			$obj->write();
-			
+
 			die('1');
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Unsubscribe a user from a thread by an ID
 	 *
@@ -572,22 +572,22 @@ class Forum_Controller extends Page_Controller {
 	 */
 	function unsubscribe(SS_HTTPRequest $request) {
 		$member = Member::currentUser();
-		
+
 		if(!$member) Security::permissionFailure($this, _t('LOGINTOUNSUBSCRIBE', 'To unsubscribe from that thread, please log in first.'));
-		
+
 		if(ForumThread_Subscription::already_subscribed($this->urlParams['ID'], $member->ID)) {
 
 			DB::query("
-				DELETE FROM \"ForumThread_Subscription\" 
-				WHERE \"ThreadID\" = '". Convert::raw2sql($this->urlParams['ID']) ."' 
+				DELETE FROM \"ForumThread_Subscription\"
+				WHERE \"ThreadID\" = '". Convert::raw2sql($this->urlParams['ID']) ."'
 				AND \"MemberID\" = '$member->ID'");
-			
+
 			die('1');
 		}
 
 		return false;
 	}
-	
+
 	/**
 	 * Mark a post as spam. Deletes any posts or threads created by that user
 	 * and removes their user account from the site
@@ -615,7 +615,7 @@ class Forum_Controller extends Page_Controller {
 
 			// Log deletion event
 			SS_Log::log(sprintf(
-				'Marked post #%d as spam, by moderator %s (#%d)', 
+				'Marked post #%d as spam, by moderator %s (#%d)',
 				$post->ID,
 				$currentUser->Email,
 				$currentUser->ID
@@ -689,7 +689,7 @@ class Forum_Controller extends Page_Controller {
 
 	/**
 	 * Get posts to display. This method assumes an URL parameter "ID" which contains the thread ID.
-	 * @param string sortDirection The sort order direction, either ASC for ascending (default) or DESC for descending 
+	 * @param string sortDirection The sort order direction, either ASC for ascending (default) or DESC for descending
 	 * @return DataObjectSet Posts
 	 */
 	function Posts($sortDirection = "ASC") {
@@ -748,23 +748,23 @@ class Forum_Controller extends Page_Controller {
 			  	.'If you want to log in as someone else, do so below. If you\'re logged in and you still can\'t post, you don\'t have the correct permissions to post.'),
 			'logInAgain' => _t('Forum.LOGINTOPOSTAGAIN','You have been logged out of the forums.  If you would like to log in again to post, enter a username and password below.'),
 		);
-		
+
 		// Creating new thread
 		if ($addMode && !$this->canPost()) {
  			Security::permissionFailure($this, $messageSet);
-			return false;			
+			return false;
 		}
 
 		// Replying to existing thread
 		if (!$addMode && !$post && $thread && !$thread->canPost()) {
  			Security::permissionFailure($this, $messageSet);
-			return false;			
+			return false;
 		}
 
 		// Editing existing post
 		if (!$addMode && $post && !$post->canEdit()) {
  			Security::permissionFailure($this, $messageSet);
-			return false;			
+			return false;
 		}
 
 		$forumBBCodeHint = $this->renderWith('Forum_BBCodeHint');
@@ -773,25 +773,25 @@ class Forum_Controller extends Page_Controller {
 			($post && $post->isFirstPost() || !$thread) ? new TextField("Title", _t('Forum.FORUMTHREADTITLE', 'Title')) : new ReadonlyField('Title',  _t('Forum.FORUMTHREADTITLE', ''), 'Re:'. $thread->Title),
 			new TextareaField("Content", _t('Forum.FORUMREPLYCONTENT', 'Content')),
 			new LiteralField(
-				"BBCodeHelper", 
-				"<div class=\"BBCodeHint\">[ <a href=\"#BBTagsHolder\" id=\"BBCodeHint\">" . 
-				_t('Forum.BBCODEHINT','View Formatting Help') . 
-				"</a> ]</div>" . 
+				"BBCodeHelper",
+				"<div class=\"BBCodeHint\">[ <a href=\"#BBTagsHolder\" id=\"BBCodeHint\">" .
+				_t('Forum.BBCODEHINT','View Formatting Help') .
+				"</a> ]</div>" .
 				$forumBBCodeHint
 			),
-			new CheckboxField("TopicSubscription", 
-				_t('Forum.SUBSCRIBETOPIC','Subscribe to this topic (Receive email notifications when a new reply is added)'), 
+			new CheckboxField("TopicSubscription",
+				_t('Forum.SUBSCRIBETOPIC','Subscribe to this topic (Receive email notifications when a new reply is added)'),
 				($thread) ? $thread->getHasSubscribed() : false)
 		);
-		
+
 		if($thread) $fields->push(new HiddenField('ThreadID', 'ThreadID', $thread->ID));
 		if($post) $fields->push(new HiddenField('ID', 'ID', $post->ID));
-		
+
 		// Check if we can attach files to this forum's posts
 		if($this->canAttach()) {
 			$fields->push(FileField::create("Attachment", _t('Forum.ATTACH', 'Attach file')));
 		}
-		
+
 		// If this is an existing post check for current attachments and generate
 		// a list of the uploaded attachments
 		if($post && $attachmentList = $post->Attachments()) {
@@ -810,11 +810,11 @@ class Forum_Controller extends Page_Controller {
 							. _t('Forum.REMOVE','remove') . "</a>]</li>";
 				}
 				$attachments .= "</ul></div>";
-			
+
 				$fields->push(new LiteralField('CurrentAttachments', $attachments));
 			}
 		}
-		
+
 		$actions = new FieldList(
 			new FormAction("doPostMessageForm", _t('Forum.REPLYFORMPOST', 'Post'))
 		);
@@ -826,24 +826,24 @@ class Forum_Controller extends Page_Controller {
 		$this->extend('updatePostMessageForm', $form, $post);
 
 		if($post) $form->loadDataFrom($post);
-		
+
 		return $form;
 	}
-	
+
 	/**
 	 * Wrapper for older templates. Previously the new, reply and edit forms were 3 separate
-	 * forms, they have now been refactored into 1 form. But in order to not break existing 
+	 * forms, they have now been refactored into 1 form. But in order to not break existing
 	 * themes too much just include this.
 	 *
-	 * @deprecated 0.5 
+	 * @deprecated 0.5
 	 * @return Form
 	 */
 	function ReplyForm() {
 		user_error('Please Use $PostMessageForm in your template rather that $ReplyForm', E_USER_WARNING);
-		
+
 		return $this->PostMessageForm();
 	}
-	
+
 	/**
 	 * Post a message to the forum. This method is called whenever you want to make a
 	 * new post or edit an existing post on the forum
@@ -868,7 +868,7 @@ class Forum_Controller extends Page_Controller {
 		$post = false;
 		if(isset($data['ID'])) {
 			$post = DataObject::get_by_id('Post', $data['ID']);
-			
+
 			if($post && $post->isFirstPost()) {
 				if($title) {
 					$thread->Title = $title;
@@ -883,23 +883,23 @@ class Forum_Controller extends Page_Controller {
 			'alreadyLoggedIn' => _t('Forum.NOPOSTPERMISSION','I\'m sorry, but you do not have permission post to this forum.'),
 			'logInAgain' => _t('Forum.LOGINTOPOSTAGAIN','You have been logged out of the forums.  If you would like to log in again to post, enter a username and password below.'),
 		);
-		
+
 		// Creating new thread
 		if (!$thread && !$this->canPost()) {
  			Security::permissionFailure($this, $messageSet);
-			return false;			
+			return false;
 		}
 
 		// Replying to existing thread
 		if ($thread && !$post && !$thread->canPost()) {
  			Security::permissionFailure($this, $messageSet);
-			return false;			
+			return false;
 		}
 
 		// Editing existing post
 		if ($thread && $post && !$post->canEdit()) {
  			Security::permissionFailure($this, $messageSet);
-			return false;			
+			return false;
 		}
 
 		if(!$thread) {
@@ -908,25 +908,25 @@ class Forum_Controller extends Page_Controller {
 			if($title) $thread->Title = $title;
 			$starting_thread = true;
 		}
-		
+
 		// Upload and Save all files attached to the field
 		// Attachment will always be blank, If they had an image it will be at least in Attachment-0
 		//$attachments = new DataObjectSet();
 		$attachments = new ArrayList();
-		
+
 		if(!empty($data['Attachment-0']) && !empty($data['Attachment-0']['tmp_name'])) {
 			$id = 0;
-			// 
+			//
 			// @todo this only supports ajax uploads. Needs to change the key (to simply Attachment).
 			//
 			while(isset($data['Attachment-' . $id])) {
 				$image = $data['Attachment-' . $id];
-					
+
 				if($image && !empty($image['tmp_name'])) {
 					$file = Post_Attachment::create();
 					$file->OwnerID = Member::currentUserID();
-					$folder = Config::inst()->get('ForumHolder','attachments_folder');	
-					
+					$folder = Config::inst()->get('ForumHolder','attachments_folder');
+
 					try {
 						$upload = Upload::create()->loadIntoFile($image, $file, $folder);
 						$file->write();
@@ -936,31 +936,31 @@ class Forum_Controller extends Page_Controller {
 						$message = _t('Forum.UPLOADVALIDATIONFAIL', 'Unallowed file uploaded. Please only upload files of the following: ');
 						$message .= implode(', ', Config::inst()->get('File', 'allowed_extensions'));
 						$form->addErrorMessage('Attachment', $message, 'bad');
-						
+
 						Session::set("FormInfo.Form_PostMessageForm.data", $data);
-						
+
 						return $this->redirectBack();
 					}
 				}
-				
+
 				$id++;
-			}	
+			}
 		}
 
 		// from now on the user has the correct permissions. save the current thread settings
 		$thread->write();
-		
+
 		if(!$post || !$post->canEdit()) {
 			$post = new Post();
 			$post->AuthorID = ($member) ? $member->ID : 0;
 			$post->ThreadID = $thread->ID;
 		}
-		
+
 		$post->ForumID = $thread->ForumID;
 		$post->Content = $content;
 		$post->write();
-		
-		
+
+
 		if($attachments) {
 			foreach($attachments as $attachment) {
 				$attachment->PostID = $post->ID;
@@ -985,16 +985,16 @@ class Forum_Controller extends Page_Controller {
 
 		// Send any notifications that need to be sent
 		ForumThread_Subscription::notify($post);
-		
+
 		// Send any notifications to moderators of the forum
 		if (Forum::$notify_moderators) {
 			if(isset($starting_thread) && $starting_thread) $this->notifyModerators($post, $thread, true);
 			else $this->notifyModerators($post, $thread);
 		}
-		
+
 		return $this->redirect($post->Link());
 	}
-	
+
 	/**
 	 * Send email to moderators notifying them the thread has been created or post added/edited.
 	 */
@@ -1021,14 +1021,14 @@ class Forum_Controller extends Page_Controller {
 						'Forum' => $this,
 						'Post' => $post
 					)));
-					
+
 					$email->send();
 				}
 			}
 		}
 	}
-	
-	/** 
+
+	/**
 	 * Return the Forbidden Words in this Forum
 	 *
 	 * @return Text
@@ -1036,7 +1036,7 @@ class Forum_Controller extends Page_Controller {
 	function getForbiddenWords() {
 		return $this->Parent()->ForbiddenWords;
 	}
-	
+
 	/**
 	* This function filters $content by forbidden words, entered in forum holder.
 	*
@@ -1051,7 +1051,7 @@ class Forum_Controller extends Page_Controller {
 				$content = str_ireplace(trim($word),"*",$content);
 			}
 		}
-		
+
 		return $content;
 	}
 
@@ -1066,7 +1066,7 @@ class Forum_Controller extends Page_Controller {
 
 	/**
 	 * Show will get the selected thread to the user. Also increments the forums view count.
-	 * 
+	 *
 	 * If the thread does not exist it will pass the user to the 404 error page
 	 *
 	 * @return array|SS_HTTPResponse_Exception
@@ -1075,7 +1075,7 @@ class Forum_Controller extends Page_Controller {
 		$title = Convert::raw2xml($this->Title);
 
 		if($thread = $this->getForumThread()) {
-			
+
 			//If there is not first post either the thread has been removed or thread if a banned spammer.
 			if(!$thread->getFirstPost()){
 				// don't hide the post for logged in admins or moderators
@@ -1147,20 +1147,20 @@ class Forum_Controller extends Page_Controller {
 				if($thread = DataObject::get_by_id('ForumThread', $SQL_id)) {
 					if(!$thread->canView()) {
 						Security::permissionFailure($this);
-						
+
 						return false;
 					}
-					
+
 					return $thread;
 				}
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
-	 * Delete an Attachment 
+	 * Delete an Attachment
 	 * Called from the EditPost method. Its Done via Ajax
 	 *
 	 * @return boolean
@@ -1173,15 +1173,15 @@ class Forum_Controller extends Page_Controller {
 
 		// check we were passed an id and member is logged in
 		if(!isset($this->urlParams['ID'])) return false;
-		
+
 		$file = DataObject::get_by_id("Post_Attachment", (int) $this->urlParams['ID']);
-	
+
 		if($file && $file->canDelete()) {
 			$file->delete();
-		
+
 			return (!Director::is_ajax()) ? $this->redirectBack() : true;
 		}
-		
+
 		return false;
 	}
 
@@ -1207,7 +1207,7 @@ class Forum_Controller extends Page_Controller {
 
 		return $this->PostMessageForm(false, $post);
 	}
-	
+
 
 	/**
 	 * Delete a post via the url.
@@ -1236,10 +1236,10 @@ class Forum_Controller extends Page_Controller {
 				}
 			}
 	  	}
-		
+
 		return (Director::is_ajax()) ? true : $this->redirect($this->Link());
 	}
-	
+
 	/**
 	 * Returns the Forum Message from Session. This
 	 * is used for things like Moving thread messages
@@ -1248,13 +1248,13 @@ class Forum_Controller extends Page_Controller {
 	function ForumAdminMsg() {
 		$message = Session::get('ForumAdminMsg');
 		Session::clear('ForumAdminMsg');
-		
+
 		return $message;
 	}
-	
-	
-	/** 
-	 * Forum Admin Features form. 
+
+
+	/**
+	 * Forum Admin Features form.
 	 * Handles the dropdown to select the new forum category and the checkbox for stickyness
 	 *
 	 * @return Form
@@ -1263,25 +1263,25 @@ class Forum_Controller extends Page_Controller {
 		if (!$this->canModerate()) return;
 
 		$id = (isset($this->urlParams['ID'])) ? $this->urlParams['ID'] : false;
-		
+
 		$fields = new FieldList(
 			new CheckboxField('IsSticky', _t('Forum.ISSTICKYTHREAD','Is this a Sticky Thread?')),
 			new CheckboxField('IsGlobalSticky', _t('Forum.ISGLOBALSTICKY','Is this a Global Sticky (shown on all forums)')),
 			new CheckboxField('IsReadOnly', _t('Forum.ISREADONLYTHREAD','Is this a Read only Thread?')),
 			new HiddenField("ID", "Thread")
 		);
-		
+
 		if(($forums = Forum::get()) && $forums->exists()) {
 			$fields->push(new DropdownField("ForumID", _t('Forum.CHANGETHREADFORUM',"Change Thread Forum"), $forums->map('ID', 'Title', 'Select New Category:')), '', null, 'Select New Location:');
 		}
-	
+
 		$actions = new FieldList(
 			new FormAction('doAdminFormFeatures', _t('Forum.SAVE', 'Save'))
 		);
-		
+
 		$form = new Form($this, 'AdminFormFeatures', $fields, $actions);
-		
-		// need this id wrapper since the form method is called on save as 
+
+		// need this id wrapper since the form method is called on save as
 		// well and needs to return a valid form object
 		if($id) {
 			$thread = ForumThread::get()->byID($id);
@@ -1290,8 +1290,8 @@ class Forum_Controller extends Page_Controller {
 
 		return $form;
 	}
-	
-	/** 
+
+	/**
 	 * Process's the moving of a given topic. Has to check for admin privledges,
 	 * passed an old topic id (post id in URL) and a new topic id
 	 */
@@ -1303,12 +1303,12 @@ class Forum_Controller extends Page_Controller {
 				if (!$thread->canModerate()) {
 					return Security::permissionFailure($this);
 				}
-				
+
 				$form->saveInto($thread);
 				$thread->write();
 			}
 		}
-		
+
 		return $this->redirect($this->Link());
 	}
 }


### PR DESCRIPTION
This was allowing CMS users to see the ban and ghost links on their own posts. This was mentioned in #120 where any CMS user could see the ban and ghost links rather than those explicitly tagged as moderators.