### PR TITLE
Adding $has_many relationship back from Member to Post

### DIFF
--- a/code/extensions/ForumRole.php
+++ b/code/extensions/ForumRole.php
@@ -64,6 +64,10 @@ class ForumRole extends DataExtension {
 		'Avatar' => 'Image'
 	);
 
+	private static $has_many = array(
+		'ForumPosts' => 'Post'
+	);
+
 	private static $belongs_many_many = array(
 		'ModeratedForums' => 'Forum'
 	);
@@ -130,7 +134,7 @@ class ForumRole extends DataExtension {
 	}
 	function NumPosts() {
 		if(is_numeric($this->owner->ID)) {
-			return (int)DB::query("SELECT count(*) FROM \"Post\" WHERE \"AuthorID\" = '" . $this->owner->ID . "'")->value();
+			return $this->owner->ForumPosts()->Count();
 		} else {
 			return 0;
 		}

--- a/code/model/Post.php
+++ b/code/model/Post.php
@@ -30,6 +30,14 @@ class Post extends DataObject {
 	private static $has_many = array(
 		"Attachments" => "Post_Attachment"
 	);
+	
+	private static $summary_fields = array(
+		"Content.LimitWordCount" => "Summary",
+		"Created" => "Created",
+		"Status" => "Status",
+		"Thread.Title" => "Thread",
+		"Forum.Title" => "Forum"
+	);
 
 	/**
 	 * Update all the posts to have a forum ID of their thread ID. 


### PR DESCRIPTION
Adding $has_many link back from Member to Post so posts can be accessed from the member side of the relationship. This allows us to retrieve Posts for the Member through the ORM.