### PR TITLE
Fix issue where $addMode is implicitly true

### DIFF
--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -734,14 +734,16 @@ class Forum_Controller extends Page_Controller {
 	function PostMessageForm($addMode = false, $post = false) {
 		$thread = false;
 
-		if ($addMode && strtolower($addMode) == 'false') {
-    		$addMode = false;
-		}
-
 		if($post) {
 			$thread = $post->Thread();
 		} else if(isset($this->urlParams['ID']) && is_numeric($this->urlParams['ID'])) {
 			$thread = DataObject::get_by_id('ForumThread', $this->urlParams['ID']);
+		}
+
+		if (!$thread) {
+			$addMode = true;
+		} elseif ($addMode && strtolower($addMode) == 'false') {
+			$addMode = false;
 		}
 
 		// Check permissions
@@ -1294,9 +1296,9 @@ class Forum_Controller extends Page_Controller {
 			$thread = ForumThread::get()->byID($id);
 			$form->loadDataFrom($thread);
 		}
-		
+
 		$this->extend('updateAdminFormFeatures', $form);
-		
+
 		return $form;
 	}
 


### PR DESCRIPTION
This will get the test passing and also puts the form in implicit add mode if there's no thread