### PR TITLE
SS-2015-017: Remove form actions from allowed_actions

### DIFF
--- a/code/controllers/ForumMemberProfile.php
+++ b/code/controllers/ForumMemberProfile.php
@@ -12,7 +12,6 @@ class ForumMemberProfile extends Page_Controller {
 		'RegistrationForm',
 		'registerwithopenid',
 		'RegistrationWithOpenIDForm',
-		'doregister',
 		'edit',
 		'EditProfileForm',
 		'thanks',

--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -469,8 +469,6 @@ class Forum_Controller extends Page_Controller {
 		'AdminFormFeatures',
 		'deleteattachment',
 		'deletepost',
-		'doAdminFormFeatures',
-		'doPostMessageForm',
 		'editpost',
 		'markasspam',
 		'PostMessageForm',


### PR DESCRIPTION
A number of form actions in the Forum module are directly accessible. A malicious user (e.g. spammer) can use GET requests to create Members and post to forums, bypassing CSRF and anti-spam measures.

Additionally, a forum moderator could be tricked into clicking a specially crafted URL, resulting in a topic being moved.