### PR TITLE
BUGFIX: Deleting Post deletes Member with correlating ID

### DIFF
--- a/code/extensions/ForumSpamPostExtension.php
+++ b/code/extensions/ForumSpamPostExtension.php
@@ -16,15 +16,7 @@ class ForumSpamPostExtension extends DataExtension {
 		}
 
 		$query->addWhere($filter);
-
-		// Filter out posts where the author is in some sort of banned / suspended status
-
-		$query->addInnerJoin("Member", "\"AuthorStatusCheck\".\"ID\" = \"Post\".\"AuthorID\"", "AuthorStatusCheck");
-
-		$authorStatusFilter = '"AuthorStatusCheck"."ForumStatus" = \'Normal\'';
-		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR "Post"."AuthorID" = '. $member->ID;
-
-		$query->addWhere($authorStatusFilter);
+		
 		$query->setDistinct(false);
 	}
 

--- a/code/model/Post.php
+++ b/code/model/Post.php
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * Forum Post Object. Contains a single post by the user. A thread is generated 
+ * Forum Post Object. Contains a single post by the user. A thread is generated
  * with multiple posts.
  *
  * @package forum
  */
 
 class Post extends DataObject {
-	
+
 	private static $db = array(
 		"Content" => "Text",
 		"Status" => "Enum('Awaiting, Moderated, Rejected, Archived', 'Moderated')",
@@ -32,7 +32,7 @@ class Post extends DataObject {
 	);
 
 	/**
-	 * Update all the posts to have a forum ID of their thread ID. 
+	 * Update all the posts to have a forum ID of their thread ID.
 	 */
 	function requireDefaultRecords() {
 		$posts = Post::get()->filter(array('ForumID' => 0, 'ThreadID:GreaterThan' => 0));
@@ -44,23 +44,23 @@ class Post extends DataObject {
 					$post->write();
 				}
 			}
-			
+
 			DB::alteration_message(_t('Forum.POSTSFORUMIDUPDATED', 'Forum posts forum ID added'), 'created');
 		}
 	}
-	
+
 	/**
 	 * Before deleting a post make sure all attachments are also deleted
 	 */
 	function onBeforeDelete() {
 		parent::onBeforeDelete();
-		
+
 		if($attachments = $this->Attachments()) {
 			foreach($attachments as $file) {
 				$file->delete();
 				$file->destroy();
 			}
-		}	
+		}
 	}
 
 	/**
@@ -68,6 +68,13 @@ class Post extends DataObject {
 	 */
 	function canView($member = null) {
 		if(!$member) $member = Member::currentUser();
+
+		if($this->Author()->ForumStatus != 'Normal') {
+			if($this->AuthorID != $member->ID || $member->ForumStatus != 'Ghost') {
+				return false;
+			}
+		}
+
 		return $this->Thread()->canView($member);
 	}
 
@@ -76,18 +83,18 @@ class Post extends DataObject {
 	 */
 	function canEdit($member = null) {
 		if(!$member) $member = Member::currentUser();
-		
+
 		if($member) {
 			// Admins can always edit, regardless of thread/post ownership
 			if(Permission::checkMember($member, 'ADMIN')) return true;
 
 			// Otherwise check for thread permissions and ownership
 			if($this->Thread()->canPost($member) && $member->ID == $this->AuthorID) return true;
-		} 
+		}
 
 		return false;
 	}
-	
+
 	/**
 	 * Follow edit permissions for this, but additionally allow moderation even
 	 * if the thread is marked as readonly.
@@ -100,7 +107,7 @@ class Post extends DataObject {
 			return $this->Thread()->canModerate($member);
 		}
 	}
-	
+
 	/**
 	 * Check if user can add new posts - hook up into canPost.
 	 */
@@ -108,7 +115,7 @@ class Post extends DataObject {
 		if(!$member) $member = Member::currentUser();
 		return $this->Thread()->canPost($member);
 	}
-	
+
 	/**
 	 * Returns the absolute url rather then relative. Used in Post RSS Feed
 	 *
@@ -121,7 +128,7 @@ class Post extends DataObject {
 	/**
 	 * Return the title of the post. Because we don't have to have the title
 	 * on individual posts check with the topic
-	 * 
+	 *
 	 * @return String
 	 */
 	function getTitle() {
@@ -134,7 +141,7 @@ class Post extends DataObject {
 	function getUpdated() {
 		if($this->LastEdited != $this->Created) return $this->LastEdited;
 	}
-	
+
 	/**
 	 * Is this post the first post in the thread. Check if their is a post with an ID less
 	 * than the one of this post in the same thread
@@ -150,10 +157,10 @@ class Post extends DataObject {
 		))->value();
 		return empty($earlierPosts);
 	}
-	
+
 	/**
 	 * Return a link to edit this post.
-	 * 
+	 *
 	 * @return String
 	 */
 	function EditLink() {
@@ -166,7 +173,7 @@ class Post extends DataObject {
 
 	/**
 	 * Return a link to delete this post.
-	 * 
+	 *
 	 * If the member is an admin of this forum, (ADMIN permissions
 	 * or a moderator) then they can delete the post.
 	 *
@@ -182,10 +189,10 @@ class Post extends DataObject {
 
 			return '<a class="deleteLink' . $firstPost . '" href="' . $url . '">' . _t('Post.DELETE','Delete') . '</a>';
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Return a link to the reply form. Permission checking is handled on the actual URL
 	 * and not on this function
@@ -197,7 +204,7 @@ class Post extends DataObject {
 
 		return '<a href="' . $url . '" class="replyLink">' . _t('Post.REPLYLINK','Post Reply') . '</a>';
 	}
-		
+
 	/**
 	 * Return a link to the post view.
 	 *
@@ -205,10 +212,10 @@ class Post extends DataObject {
 	 */
 	function ShowLink() {
 		$url = $this->Link('show');
-		
+
 		return '<a href="' . $url . '" class="showLink">' . _t('Post.SHOWLINK','Show Thread') . "</a>";
 	}
-	
+
 	/**
 	 * Return a link to mark this post as spam.
 	 * used for the spamprotection module
@@ -224,7 +231,7 @@ class Post extends DataObject {
 				$url = $token->addToUrl($url);
 
 				$firstPost = ($this->isFirstPost()) ? ' firstPost' : '';
-				
+
 				return '<a href="' . $url .'" class="markAsSpamLink' . $firstPost . '" rel="' . $this->ID . '">'. _t('Post.MARKASSPAM', 'Mark as Spam') . '</a>';
 			}
 		}
@@ -250,27 +257,27 @@ class Post extends DataObject {
 	}
 
 	/**
-	 * Return the parsed content and the information for the 
+	 * Return the parsed content and the information for the
 	 * RSS feed
 	 */
 	function getRSSContent() {
 		return $this->renderWith('Includes/Post_rss');
 	}
 
-	
+
 	function getRSSAuthor() {
 		$author = $this->Author();
-		
+
 		return $author->Nickname;
 	}
-	
+
 	/**
 	 * Return a link to show this post
 	 *
 	 * @return String
 	 */
 	function Link($action = "show") {
-		// only include the forum thread ID in the URL if we're showing the thread either 
+		// only include the forum thread ID in the URL if we're showing the thread either
 		// by showing the posts or replying therwise we only need to pass a single ID.
 		$includeThreadID = ($action == "show" || $action == "reply") ? true : false;
 		$link = $this->Thread()->Link($action, $includeThreadID);
@@ -278,14 +285,14 @@ class Post extends DataObject {
 		// calculate what page results the post is on
 		// the count is the position of the post in the thread
 		$count = DB::query("
-			SELECT COUNT(\"ID\") 
-			FROM \"Post\" 
+			SELECT COUNT(\"ID\")
+			FROM \"Post\"
 			WHERE \"ThreadID\" = '$this->ThreadID' AND \"Status\" = 'Moderated' AND \"ID\" < $this->ID
 		")->value();
 
 		$start = ($count >= Forum::$posts_per_page) ? floor($count / Forum::$posts_per_page) * Forum::$posts_per_page : 0;
 		$pos = ($start == 0 ? '' : "?start=$start") . ($count == 0 ? '' : "#post{$this->ID}");
-		
+
 		return ($action == "show") ? $link . $pos : $link;
 	}
 }
@@ -296,11 +303,11 @@ class Post extends DataObject {
  * @package forum
  */
 class Post_Attachment extends File {
-	
+
 	private static $has_one = array(
 		"Post" => "Post"
 	);
-	
+
 	private static $defaults = array(
 		'ShowInSearch' => 0
 	);
@@ -314,7 +321,7 @@ class Post_Attachment extends File {
 		if(!$member) $member = Member::currentUser();
 		return ($this->Post()) ? $this->Post()->canDelete($member) : true;
 	}
-	
+
 	/**
 	 * Can a user edit this attachement
 	 *
@@ -331,14 +338,14 @@ class Post_Attachment extends File {
 	function download() {
 		if(isset($this->urlParams['ID'])) {
 			$SQL_ID = Convert::raw2sql($this->urlParams['ID']);
-			
+
 			if(is_numeric($SQL_ID)) {
 				$file = DataObject::get_by_id("Post_Attachment", $SQL_ID);
 				$response = SS_HTTPRequest::send_file(file_get_contents($file->getFullPath()), $file->Name);
 				$response->output();
 			}
 		}
-		
+
 		return $this->redirectBack();
 	}
 }

--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -709,6 +709,26 @@ class Forum_Controller extends Page_Controller {
 
 		if(!isset($_GET['start'])) $_GET['start'] = 0;
 
+		/*
+		 * Don't show posts of banned or ghost members, unless current Member
+		 * is a ghost member and owner of current post
+		 */
+
+		$posts = $posts->exclude(array(
+			'Author.ForumStatus' => 'Banned'
+		));
+
+		if($member) {
+			$posts = $posts->exclude(array(
+				'Author.ForumStatus' => 'Ghost',
+				'Author.ID:not' => $member->ID
+			));
+		} else {
+			$posts = $posts->exclude(array(
+				'Author.ForumStatus' => 'Ghost'
+			));
+		}
+
 		$paginated = new PaginatedList($posts, $_GET);
 		$paginated->setPageLength(Forum::$posts_per_page);
 		return $paginated;
@@ -1285,9 +1305,9 @@ class Forum_Controller extends Page_Controller {
 			$thread = ForumThread::get()->byID($id);
 			$form->loadDataFrom($thread);
 		}
-		
+
 		$this->extend('updateAdminFormFeatures', $form);
-		
+
 		return $form;
 	}
 


### PR DESCRIPTION
If a forum post with ID 79 is deleted, Member with ID 79 will also be deleted bypassing the ORM.