### PR TITLE
BUGFIX: Deleting Forum Post deletes Member with correlating ID

### DIFF
--- a/code/extensions/ForumSpamPostExtension.php
+++ b/code/extensions/ForumSpamPostExtension.php
@@ -17,14 +17,6 @@ class ForumSpamPostExtension extends DataExtension {
 
 		$query->addWhere($filter);
 
-		// Filter out posts where the author is in some sort of banned / suspended status
-
-		$query->addInnerJoin("Member", "\"AuthorStatusCheck\".\"ID\" = \"Post\".\"AuthorID\"", "AuthorStatusCheck");
-
-		$authorStatusFilter = '"AuthorStatusCheck"."ForumStatus" = \'Normal\'';
-		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR "Post"."AuthorID" = '. $member->ID;
-
-		$query->addWhere($authorStatusFilter);
 		$query->setDistinct(false);
 	}
 

--- a/code/extensions/ForumSpamPostExtension.php
+++ b/code/extensions/ForumSpamPostExtension.php
@@ -16,6 +16,15 @@ class ForumSpamPostExtension extends DataExtension {
 		}
 
 		$query->addWhere($filter);
+		
+		// Filter out posts where the author is in some sort of banned / suspended status
+
+		$query->addLeftJoin("Member", "\"Member\".\"ID\" = \"Post\".\"AuthorID\"");
+
+		$authorStatusFilter = '"Member"."ForumStatus" = \'Normal\'';
+		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR "Post"."AuthorID" = ' . $member->ID;
+
+		$query->addWhere($authorStatusFilter);
 
 		$query->setDistinct(false);
 	}

--- a/code/model/Post.php
+++ b/code/model/Post.php
@@ -68,6 +68,13 @@ class Post extends DataObject {
 	 */
 	function canView($member = null) {
 		if(!$member) $member = Member::currentUser();
+		
+		if($this->Author()->ForumStatus != 'Normal') {
+			if($this->AuthorID != $member->ID || $member->ForumStatus != 'Ghost') {
+				return false;
+			}
+		}
+
 		return $this->Thread()->canView($member);
 	}
 

--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -709,6 +709,28 @@ class Forum_Controller extends Page_Controller {
 
 		if(!isset($_GET['start'])) $_GET['start'] = 0;
 
+		$member = Member::currentUser();
+
+		/*
+		 * Don't show posts of banned or ghost members, unless current Member
+		 * is a ghost member and owner of current post
+		 */
+
+		$posts = $posts->exclude(array(
+			'Author.ForumStatus' => 'Banned'
+		));
+
+		if($member) {
+			$posts = $posts->exclude(array(
+				'Author.ForumStatus' => 'Ghost',
+				'Author.ID:not' => $member->ID
+			));
+		} else {
+			$posts = $posts->exclude(array(
+				'Author.ForumStatus' => 'Ghost'
+			));
+		}
+
 		$paginated = new PaginatedList($posts, $_GET);
 		$paginated->setPageLength(Forum::$posts_per_page);
 		return $paginated;


### PR DESCRIPTION
If a forum post with ID 79 is deleted, Member with ID 79 will also be deleted bypassing the ORM.

Fixed & cleaned up #156 