### PR TITLE
BUGFIX: Deleting Forum Post deletes Member with correlating ID

### DIFF
--- a/code/extensions/ForumSpamPostExtension.php
+++ b/code/extensions/ForumSpamPostExtension.php
@@ -17,14 +17,6 @@ class ForumSpamPostExtension extends DataExtension {
 
 		$query->addWhere($filter);
 
-		// Filter out posts where the author is in some sort of banned / suspended status
-
-		$query->addInnerJoin("Member", "\"AuthorStatusCheck\".\"ID\" = \"Post\".\"AuthorID\"", "AuthorStatusCheck");
-
-		$authorStatusFilter = '"AuthorStatusCheck"."ForumStatus" = \'Normal\'';
-		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR "Post"."AuthorID" = '. $member->ID;
-
-		$query->addWhere($authorStatusFilter);
 		$query->setDistinct(false);
 	}
 

--- a/code/extensions/ForumSpamPostExtension.php
+++ b/code/extensions/ForumSpamPostExtension.php
@@ -17,6 +17,12 @@ class ForumSpamPostExtension extends DataExtension {
 
 		$query->addWhere($filter);
 
+		// Exclude Ghost member posts, but show Ghost members their own posts
+		$authorStatusFilter = 'AuthorID IN (SELECT ID FROM Member WHERE ForumStatus = \'Normal\')';
+		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR AuthorID = ' . $member->ID;
+
+		$query->addWhere($authorStatusFilter);
+
 		$query->setDistinct(false);
 	}
 

--- a/code/extensions/ForumSpamPostExtension.php
+++ b/code/extensions/ForumSpamPostExtension.php
@@ -18,8 +18,8 @@ class ForumSpamPostExtension extends DataExtension {
 		$query->addWhere($filter);
 
 		// Exclude Ghost member posts, but show Ghost members their own posts
-		$authorStatusFilter = 'AuthorID IN (SELECT ID FROM Member WHERE ForumStatus = \'Normal\')';
-		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR AuthorID = ' . $member->ID;
+		$authorStatusFilter = '"AuthorID" IN (SELECT ID FROM "Member" WHERE "ForumStatus" = \'Normal\')';
+		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR "AuthorID" = ' . $member->ID;
 
 		$query->addWhere($authorStatusFilter);
 

--- a/code/extensions/ForumSpamPostExtension.php
+++ b/code/extensions/ForumSpamPostExtension.php
@@ -18,7 +18,7 @@ class ForumSpamPostExtension extends DataExtension {
 		$query->addWhere($filter);
 
 		// Exclude Ghost member posts, but show Ghost members their own posts
-		$authorStatusFilter = '"AuthorID" IN (SELECT ID FROM "Member" WHERE "ForumStatus" = \'Normal\')';
+		$authorStatusFilter = '"AuthorID" IN (SELECT "ID" FROM "Member" WHERE "ForumStatus" = \'Normal\')';
 		if ($member && $member->ForumStatus == 'Ghost') $authorStatusFilter .= ' OR "AuthorID" = ' . $member->ID;
 
 		$query->addWhere($authorStatusFilter);

--- a/code/model/Post.php
+++ b/code/model/Post.php
@@ -68,6 +68,13 @@ class Post extends DataObject {
 	 */
 	function canView($member = null) {
 		if(!$member) $member = Member::currentUser();
+		
+		if($this->Author()->ForumStatus != 'Normal') {
+			if($this->AuthorID != $member->ID || $member->ForumStatus != 'Ghost') {
+				return false;
+			}
+		}
+
 		return $this->Thread()->canView($member);
 	}
 

--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -709,6 +709,28 @@ class Forum_Controller extends Page_Controller {
 
 		if(!isset($_GET['start'])) $_GET['start'] = 0;
 
+		$member = Member::currentUser();
+
+		/*
+		 * Don't show posts of banned or ghost members, unless current Member
+		 * is a ghost member and owner of current post
+		 */
+
+		$posts = $posts->exclude(array(
+			'Author.ForumStatus' => 'Banned'
+		));
+
+		if($member) {
+			$posts = $posts->exclude(array(
+				'Author.ForumStatus' => 'Ghost',
+				'Author.ID:not' => $member->ID
+			));
+		} else {
+			$posts = $posts->exclude(array(
+				'Author.ForumStatus' => 'Ghost'
+			));
+		}
+
 		$paginated = new PaginatedList($posts, $_GET);
 		$paginated->setPageLength(Forum::$posts_per_page);
 		return $paginated;

--- a/tests/ForumTest.php
+++ b/tests/ForumTest.php
@@ -414,4 +414,29 @@ class ForumTest extends FunctionalTest {
 
 		Forum::$notify_moderators = $notifyModerators;
 	}
+
+	/**
+	 * Confirm that when a post is deleted, Member with corresponding ID still exists
+	 *
+	 * @throws ValidationException
+	 * @throws null
+	 */
+	function testPostDeletionMemberIntegrity()
+	{
+		$checkID = 100012;
+
+		$post = new Post();
+		$post->ID = $checkID;
+		$post->write();
+
+		$user = new Member();
+		$user->ID = $checkID;
+		$user->FirstName = 'TestUser100012';
+		$user->write();
+
+		$post->delete();
+
+		$member = DataObject::get_by_id('Member', $checkID);
+		$this->assertTrue($member->ID == $checkID);
+	}
 }


### PR DESCRIPTION
If a forum post with ID 79 is deleted, Member with ID 79 will also be deleted bypassing the ORM.

Fixed #157 and included test.