### PR TITLE
Make reports compatible with Postgres and MS SQL, add unit tests

### DIFF
--- a/code/reports/ForumReport.php
+++ b/code/reports/ForumReport.php
@@ -3,46 +3,49 @@
  * Forum Reports.
  * These are some basic reporting tools which sit in the CMS for the user to view.
  * No fancy graphing tools or anything just some simple querys and numbers
- * 
+ *
  * @package forum
  */
 
 /**
  * Member Signups Report.
- * Lists the Number of people who have signed up in the past months categorized 
+ * Lists the Number of people who have signed up in the past months categorized
  * by month.
  */
 class ForumReport_MemberSignups extends SS_Report {
-	
+
 	public function title() {
 		return _t('Forum.FORUMSIGNUPS', 'Forum Signups by Month');
 	}
-	
+
 	public function sourceRecords($params = array()) {
 		$membersQuery = new SQLQuery();
-		$membersQuery->setFrom('Member');
-		$membersQuery->selectField('DATE_FORMAT("Created", \'%Y %M\')', 'Month');
-		$membersQuery->selectField('COUNT("Created")', 'Signups');
-		$membersQuery->setGroupBy('Month');
-		$membersQuery->setOrderBy('Created', 'DESC');
+		$membersQuery->setFrom('"Member"');
+		$membersQuery->setSelect(array(
+			'Month' => DB::getConn()->formattedDatetimeClause('"Created"', '%Y-%m'),
+			'Signups' => 'COUNT("Created")'
+		));
+		$membersQuery->setGroupBy('"Month"');
+		$membersQuery->setOrderBy('"Month"', 'DESC');
 		$members = $membersQuery->execute();
-		
+
 		$output = ArrayList::create();
 		foreach ($members as $member) {
+			$member['Month'] = date('Y F', strtotime($member['Month']));
 			$output->add(ArrayData::create($member));
 		}
 		return $output;
 	}
-	
+
 	public function columns() {
 		$fields = array(
 			'Month' => 'Month',
 			'Signups' => 'Signups'
 		);
-		
+
 		return $fields;
 	}
-	
+
 	public function group() {
 		return 'Forum Reports';
 	}
@@ -50,40 +53,43 @@ class ForumReport_MemberSignups extends SS_Report {
 
 /**
  * Member Posts Report.
- * Lists the Number of Posts made in the forums in the past months categorized 
+ * Lists the Number of Posts made in the forums in the past months categorized
  * by month.
  */
 class ForumReport_MonthlyPosts extends SS_Report {
-	
+
 	public function title() {
 		return _t('Forum.FORUMMONTHLYPOSTS', 'Forum Posts by Month');
 	}
-	
+
 	public function sourceRecords($params = array()) {
 		$postsQuery = new SQLQuery();
-		$postsQuery->setFrom('Post');
-		$postsQuery->selectField('DATE_FORMAT("Created", \'%Y %M\')', 'Month');
-		$postsQuery->selectField('COUNT("Created")', 'Posts');
-		$postsQuery->setGroupBy('Month');
-		$postsQuery->setOrderBy('Created', 'DESC');
+		$postsQuery->setFrom('"Post"');
+		$postsQuery->setSelect(array(
+			'Month' => DB::getConn()->formattedDatetimeClause('"Created"', '%Y-%m'),
+			'Posts' => 'COUNT("Created")'
+		));
+		$postsQuery->setGroupBy('"Month"');
+		$postsQuery->setOrderBy('"Month"', 'DESC');
 		$posts = $postsQuery->execute();
-		
+
 		$output = ArrayList::create();
 		foreach ($posts as $post) {
+			$post['Month'] = date('Y F', strtotime($post['Month']));
 			$output->add(ArrayData::create($post));
 		}
 		return $output;
 	}
-	
+
 	public function columns() {
 		$fields = array(
 			'Month' => 'Month',
 			'Posts' => 'Posts'
 		);
-		
+
 		return $fields;
 	}
-	
+
 	public function group() {
 		return 'Forum Reports';
 	}

--- a/tests/ForumReportTest.php
+++ b/tests/ForumReportTest.php
@@ -1,0 +1,65 @@
+<?php
+
+class ForumReportTest extends FunctionalTest {
+
+	protected static $fixture_file = 'forum/tests/ForumTest.yml';
+	protected static $use_draft_site = true;
+
+	public function setUp() {
+		parent::setUp();
+
+		$member = $this->objFromFixture('Member', 'admin');
+		$member->logIn();
+	}
+
+	public function tearDown() {
+		if($member = Member::currentUser()) $member->logOut();
+
+		parent::tearDown();
+	}
+
+	public function testMemberSignupsReport() {
+		$r = new ForumReport_MemberSignups();
+		$before = $r->records(array());
+
+		// Create a new Member in current month
+		$member = new Member();
+		$member->Email = 'testMemberSignupsReport';
+		$member->write();
+
+		// Ensure the signup count for current month has increased by one
+		$this->assertEquals((int)$before->first()->Signups + 1, (int)$r->records(array())->first()->Signups);
+
+		// Move our member to have signed up in April 2015 and check that month's signups
+		$member->Created = '2015-04-01 12:00:00';
+		$member->write();
+		$this->assertEquals(1, $r->records(array())->find('Month', '2015 April')->Signups);
+
+		// We should now be back to our original number of members in current month
+		$this->assertEquals((int)$before->first()->Signups, (int)$r->records(array())->first()->Signups);
+	}
+
+	public function testMonthlyPostsReport() {
+		$r = new ForumReport_MonthlyPosts();
+		$before = $r->records(array());
+
+		// Create a new post in current month
+		$post = new Post();
+		$post->AuthorID = $this->objFromFixture('Member', 'test2')->ID;
+		$post->ThreadID = $this->objFromFixture('ForumThread', 'Thread2')->ID;
+		$post->ForumID = $this->objFromFixture('Forum', 'forum5')->ID;
+		$post->write();
+
+		// Ensure the post count for current month has increased by one
+		$this->assertEquals((int)$before->first()->Posts + 1, (int)$r->records(array())->first()->Posts);
+
+		// Move our post to April 2015 and ensure there are two posts (one is specified in fixture file)
+		$post->Created = '2015-04-01 12:00:00';
+		$post->write();
+		$this->assertEquals(2, $r->records(array())->find('Month', '2015 April')->Posts);
+
+		// We should now be back to our original number of posts in current month
+		$this->assertEquals((int)$before->first()->Posts, (int)$r->records(array())->first()->Posts);
+	}
+
+}

--- a/tests/ForumTest.yml
+++ b/tests/ForumTest.yml
@@ -222,6 +222,7 @@ Post:
 		Thread: =>ForumThread.Thread1
 		Forum: =>Forum.general
 		Author: =>Member.test1
+		Created: '2015-04-23 01:00:00'
 	Post2:
 		Content: This is a reply to the first post
 		Thread: =>ForumThread.Thread1


### PR DESCRIPTION
The fix for reports implemented in #164 unfortunately broke Postgres and MS SQL support by using DATE_FORMAT and insufficient escaping. Additionally, unit tests for reports have been added to catch such issues in future.