### PR TITLE
FIX Explicitly set the route to the ForumMemberProfile

### DIFF
--- a/_config/forum.yml
+++ b/_config/forum.yml
@@ -1,6 +1,9 @@
 ---
 Name: forum
 ---
+Director:
+  rules:
+    'ForumMemberProfile//$Action/$ID/$OtherID': 'ForumMemberProfile'
 Member:
   extensions:
     ForumRole:


### PR DESCRIPTION
This should be backwards compatible with SS3.1 and allows 0.8 to work on SS3.2