### PR TITLE
Removing duplicate header

### DIFF
--- a/code/pagetypes/Forum.php
+++ b/code/pagetypes/Forum.php
@@ -216,8 +216,6 @@ class Forum extends Page {
 			Requirements::css("forum/css/Forum_CMS.css");
 
 			$fields->addFieldToTab("Root.Access", new HeaderField(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
-
-			$fields->addFieldToTab("Root.Access", new HeaderField(_t('Forum.ACCESSPOST','Who can post to the forum?'), 2));
 			$fields->addFieldToTab("Root.Access", $optionSetField = new OptionsetField("CanPostType", "", array(
 				"Inherit" => "Inherit",
 				"Anyone" => _t('Forum.READANYONE', 'Anyone'),


### PR DESCRIPTION
Removing duplicate 'Who can post to the forum' header. So nice, we said it twice.